### PR TITLE
Upgrade Elasticsearch chart version to 7.13.4

### DIFF
--- a/charts/paas-kuzzle/Chart.yaml
+++ b/charts/paas-kuzzle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
In order to get access to a templating fix on the Network Policies file, we need to upgrade the used version to at least 7.13.1


