### PR TITLE
Add ability to declare additional labels on Kuzzle pods

### DIFF
--- a/charts/kuzzle/Chart.yaml
+++ b/charts/kuzzle/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kuzzle/templates/deployment.yaml
+++ b/charts/kuzzle/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "kuzzle.fullname" . }}
   labels:
     {{- include "kuzzle.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -21,6 +24,9 @@ spec:
     {{- end }}
       labels:
         {{- include "kuzzle.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kuzzle/values.yaml
+++ b/charts/kuzzle/values.yaml
@@ -11,6 +11,9 @@ image:
 
 imagePullSecrets: []
 
+labels: {}
+podLabels: {}
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -33,7 +36,7 @@ extraEnvs:
   - name: NODE_ENV
     value: production
 
-command: [ "kuzzle", "start" ]
+command: ["kuzzle", "start"]
 args: []
 
 entrypoints:
@@ -67,7 +70,8 @@ metrics:
   port: 7512
   path: "/_/prometheus/metrics"
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -75,7 +79,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
Add ability to declare additional labels on Kuzzle pods from Chart values using:
- `labels`: for deployment labels
- `podLabels`: for pods labels