### PR TITLE
Add initContainer support for Kuzzle chart

### DIFF
--- a/charts/kuzzle/Chart.yaml
+++ b/charts/kuzzle/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kuzzle/templates/deployment.yaml
+++ b/charts/kuzzle/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      
+      # Init containers
+      {{ if .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.extraInitContainers | nindent 8 }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/kuzzle/values.yaml
+++ b/charts/kuzzle/values.yaml
@@ -97,3 +97,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Extra Containers to run before the main container in the pod (e.g. for sidecar containers)
+# extraContainers:
+#   - name: my-sidecar
+#     image: my-sidecar-image
+#     imagePullPolicy: Always
+#     resources:
+#       {}
+#     volumeMounts:
+#       - name: my-volume
+#         mountPath: /path/to/my-volume
+extraInitContainers: []


### PR DESCRIPTION
# Why?

To allow users to do something before the Kuzzle is executed (update Vault file with third party secrets etc...) we need to declare customisable initContainers