### PR TITLE
Add ChirpStack helm chart

### DIFF
--- a/charts/chirpstack/.helmignore
+++ b/charts/chirpstack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/chirpstack/Chart.yaml
+++ b/charts/chirpstack/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: chirpstack
+description: ChirpStack Kubernetes Chart
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "4.2.0"

--- a/charts/chirpstack/templates/_helpers.tpl
+++ b/charts/chirpstack/templates/_helpers.tpl
@@ -28,6 +28,10 @@ If release name contains chart name it will be used as a full name.
 {{- printf "%s-core" (include "chirpstack.fullname" .) -}}
 {{- end -}}
 
+{{- define "chirpstack.restApi" -}}
+{{- printf "%s-rest-api" (include "chirpstack.fullname" .) -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/chirpstack/templates/_helpers.tpl
+++ b/charts/chirpstack/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chirpstack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chirpstack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "chirpstack.core" -}}
+{{- printf "%s-core" (include "chirpstack.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chirpstack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chirpstack.labels" -}}
+helm.sh/chart: {{ include "chirpstack.chart" . }}
+{{ include "chirpstack.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chirpstack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chirpstack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: SERVER
               value: "{{ include "chirpstack.core" . }}:{{ .Values.chirpstack.http.port }}"
             - name: BIND
-              value: "0.0.0.0:{{ .Values.chirpstackRestApi.http.port }}"
+              value: "0.0.0.0:{{ .Values.chirpstackRestApi.http.containerPort }}"
             - name: CORS
               value: "{{ .Values.chirpstackRestApi.http.cors }}"
             {{- if .Values.chirpstackRestApi.http.insecure }}
@@ -52,7 +52,7 @@ spec:
             {{- toYaml .Values.chirpstackRestApi.args | nindent 12 }}
           ports:
             - name: api
-              containerPort: {{ .Values.chirpstackRestApi.http.port }}
+              containerPort: {{ .Values.chirpstackRestApi.http.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
@@ -51,17 +51,17 @@ spec:
           args:
             {{- toYaml .Values.chirpstackRestApi.args | nindent 12 }}
           ports:
-            - name: http
+            - name: api
               containerPort: {{ .Values.chirpstackRestApi.http.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /
-              port: http
+              port: api
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: api
           resources:
             {{- toYaml .Values.chirpstackRestApi.resources | nindent 12 }}
       {{- with .Values.chirpstackRestApi.nodeSelector }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.chirpstackRestApi.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chirpstack.restApi" . }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.chirpstackRestApi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chirpstack.selectorLabels" . | nindent 6 }}
+      component: restApi
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.chirpstackRestApi.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "chirpstack.selectorLabels" . | nindent 8 }}
+        component: restApi
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.chirpstackRestApi.name }}
+          securityContext:
+            {{- toYaml .Values.chirpstackRestApi.securityContext | nindent 12 }}
+          image: "{{ .Values.chirpstackRestApi.image.repository }}:{{ .Values.chirpstackRestApi.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: SERVER
+              value: "{{ include "chirpstack.core" . }}:{{ .Values.chirpstack.entrypoints.http.port }}"
+            - name: BIND
+              value: "0.0.0.0:{{ .Values.chirpstackRestApi.http.port }}"
+            - name: CORS
+              value: "{{ .Values.chirpstackRestApi.http.cors }}"
+            {{- if .Values.chirpstackRestApi.http.insecure }}
+            - name: INSECURE
+            {{- end }}
+            {{- with .Values.chirpstackRestApi.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          command:
+            {{- toYaml .Values.chirpstackRestApi.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.chirpstackRestApi.args | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.chirpstackRestApi.http.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.chirpstackRestApi.resources | nindent 12 }}
+      {{- with .Values.chirpstackRestApi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chirpstackRestApi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chirpstackRestApi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: SERVER
-              value: "{{ include "chirpstack.core" . }}:{{ .Values.chirpstack.entrypoints.http.port }}"
+              value: "{{ include "chirpstack.core" . }}:{{ .Values.chirpstack.http.port }}"
             - name: BIND
               value: "0.0.0.0:{{ .Values.chirpstackRestApi.http.port }}"
             - name: CORS

--- a/charts/chirpstack/templates/chirpstack-rest-api/ingress.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/ingress.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.chirpstackRestApi.enabled -}}
+{{- if .Values.chirpstackRestApi.ingress.enabled -}}
+{{- $fullName := include "chirpstack.restApi" . -}}
+{{- $svcPort := .Values.chirpstackRestApi.http.port -}}
+{{- if and .Values.chirpstackRestApi.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.chirpstackRestApi.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.chirpstackRestApi.ingress.annotations "kubernetes.io/ingress.class" .Values.chirpstackRestApi.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+  {{- with .Values.chirpstackRestApi.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.chirpstackRestApi.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.chirpstackRestApi.ingress.className }}
+  {{- end }}
+  {{- if .Values.chirpstackRestApi.ingress.tls }}
+  tls:
+    {{- range .Values.chirpstackRestApi.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.chirpstackRestApi.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.chirpstackRestApi.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chirpstack.restApi" . }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.chirpstackRestApi.http.port }}
+      targetPort: {{ .Values.chirpstackRestApi.http.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chirpstack.selectorLabels" . | nindent 4 }}
+    component: restApi
+{{- end }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.chirpstackRestApi.http.port }}
-      targetPort: api
+      targetPort: {{ .Values.chirpstackRestApi.http.containerPort }}
       protocol: TCP
       name: api
   selector:

--- a/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
@@ -5,8 +5,15 @@ metadata:
   name: {{ include "chirpstack.restApi" . }}
   labels:
     {{- include "chirpstack.labels" . | nindent 4 }}
+  {{- with .Values.chirpstackRestApi.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.chirpstackRestApi.service.type }}
+  {{- with .Values.chirpstackRestApi.service.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
     - port: {{ .Values.chirpstackRestApi.http.port }}
       targetPort: {{ .Values.chirpstackRestApi.http.containerPort }}

--- a/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
@@ -9,9 +9,9 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.chirpstackRestApi.http.port }}
-      targetPort: {{ .Values.chirpstackRestApi.http.targetPort }}
+      targetPort: api
       protocol: TCP
-      name: http
+      name: api
   selector:
     {{- include "chirpstack.selectorLabels" . | nindent 4 }}
     component: restApi

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -61,4 +61,4 @@ data:
           event_topic="{{ .Values.chirpstack.regions.eu868.mqtt.eventTopic }}"
           command_topic="{{ .Values.chirpstack.regions.eu868.mqtt.commandTopic }}"
 
-          server="tcp://{{ .Values.chirpstack.regions.eu868.mqtt.host }}:{{ .Values.chirpstack.regions.eu868.mqtt.port }}"
+          server="tcp://{{ .Values.chirpstack.regions.eu868.mqtt.host | default .Values.chirpstack.regions.mqtt.host }}:{{ .Values.chirpstack.regions.eu868.mqtt.port | default .Values.chirpstack.regions.mqtt.port }}"

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -43,9 +43,9 @@ data:
       secret="{{ .Values.chirpstack.apiSecret }}"
 
 
-    {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+    {{- if .Values.chirpstack.metrics.enabled }}
     [monitoring]
-      bind="0.0.0.0:{{ .Values.chirpstack.entrypoints.metrics.port }}"
+      bind="0.0.0.0:{{ .Values.chirpstack.metrics.port }}"
     {{ end }}
 
   eu868.toml: |

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -62,3 +62,7 @@ data:
           command_topic="{{ .Values.chirpstack.regions.eu868.mqtt.commandTopic }}"
 
           server="tcp://{{ .Values.chirpstack.regions.eu868.mqtt.host | default .Values.chirpstack.regions.mqtt.host }}:{{ .Values.chirpstack.regions.eu868.mqtt.port | default .Values.chirpstack.regions.mqtt.port }}"
+
+  {{- range $key, $value := .Values.chirpstack.extraConfigFiles }}
+  {{ $key | nindent 2 }}: | {{ $value | nindent 4 }}
+  {{- end }}

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -39,7 +39,7 @@ data:
 
 
     [api]
-      bind="0.0.0.0:{{ .Values.chirpstack.entrypoints.http.port }}"
+      bind="0.0.0.0:{{ .Values.chirpstack.http.port }}"
       secret="{{ .Values.chirpstack.apiSecret }}"
 
 

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "chirpstack.core" . }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+data:
+  chirpstack.toml: |
+    [logging]
+      level="{{ .Values.chirpstack.logLevel }}"
+
+
+    [postgresql]
+      dsn="postgres://{{ .Values.chirpstack.postgres.user }}:{{ .Values.chirpstack.postgres.password }}@{{ .Values.chirpstack.postgres.host }}/{{ .Values.chirpstack.postgres.database }}?sslmode={{ .Values.chirpstack.postgres.sslMode }}"
+
+      max_open_connections=10
+      min_idle_connections=0
+
+
+    [redis]
+      servers=[
+        {{- range .Values.chirpstack.redis.servers }}
+        "{{ . }}",
+        {{- end }}
+      ]
+
+      tls_enabled={{ .Values.chirpstack.redis.tlsEnabled }}
+      cluster={{ .Values.chirpstack.redis.cluster }}
+
+
+    [network]
+      net_id="{{ .Values.chirpstack.network.netId }}"
+
+      enabled_regions=[
+        {{- range .Values.chirpstack.network.enabledRegions }}
+        "{{ . }}",
+        {{- end }}
+      ]
+
+
+    [api]
+      bind="0.0.0.0:{{ .Values.chirpstack.entrypoints.http.port }}"
+      secret="{{ .Values.chirpstack.apiSecret }}"
+
+
+    {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+    [monitoring]
+      bind="0.0.0.0:{{ .Values.chirpstack.entrypoints.metrics.port }}"
+    {{ end }}
+
+  eu868.toml: |
+    [[regions]]
+    name="eu868"
+    common_name="EU868"
+
+    [regions.gateway]
+      [regions.gateway.backend]
+        enabled="mqtt"
+
+        [regions.gateway.backend.mqtt]
+          event_topic="{{ .Values.chirpstack.regions.eu868.mqtt.eventTopic }}"
+          command_topic="{{ .Values.chirpstack.regions.eu868.mqtt.commandTopic }}"
+
+          server="tcp://{{ .Values.chirpstack.regions.eu868.mqtt.host }}:{{ .Values.chirpstack.regions.eu868.mqtt.port }}"

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -39,7 +39,7 @@ data:
 
 
     [api]
-      bind="0.0.0.0:{{ .Values.chirpstack.http.port }}"
+      bind="0.0.0.0:{{ .Values.chirpstack.http.containerPort }}"
       secret="{{ .Values.chirpstack.apiSecret }}"
 
 

--- a/charts/chirpstack/templates/chirpstack/cm.yaml
+++ b/charts/chirpstack/templates/chirpstack/cm.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "chirpstack.labels" . | nindent 4 }}
 data:
+  # https://www.chirpstack.io/docs/chirpstack/configuration.html#example-chirpstacktoml-configuration
   chirpstack.toml: |
     [logging]
       level="{{ .Values.chirpstack.logLevel }}"
@@ -48,6 +49,7 @@ data:
       bind="0.0.0.0:{{ .Values.chirpstack.metrics.port }}"
     {{ end }}
 
+  # https://www.chirpstack.io/docs/chirpstack/configuration.html#example-region_eu868toml-configuration
   eu868.toml: |
     [[regions]]
     name="eu868"

--- a/charts/chirpstack/templates/chirpstack/configmap.yaml
+++ b/charts/chirpstack/templates/chirpstack/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "chirpstack.core" . }}
+  name: {{ include "chirpstack.core" . }}
   labels:
     {{- include "chirpstack.labels" . | nindent 4 }}
 data:

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chirpstack.core" . }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.chirpstack.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chirpstack.selectorLabels" . | nindent 6 }}
+      component: core
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.chirpstack.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "{{ .Values.chirpstack.entrypoints.metrics.port }}"
+        {{- end }}
+      labels:
+        {{- include "chirpstack.selectorLabels" . | nindent 8 }}
+        component: core
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.chirpstack.name }}
+          securityContext:
+            {{- toYaml .Values.chirpstack.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.chirpstack.image.repository }}:{{ .Values.chirpstack.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            {{- toYaml .Values.chirpstack.extraEnvs | nindent 12 }}
+          command:
+            {{- toYaml .Values.chirpstack.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.chirpstack.args | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/chirpstack
+          ports:
+            - name: http
+              containerPort: {{ .Values.chirpstack.entrypoints.http.port }}
+              protocol: TCP
+            {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.chirpstack.entrypoints.metrics.port }}
+              protocol: TCP
+            {{ end }}
+          {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+          {{- else }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          {{ end }}
+          resources:
+            {{- toYaml .Values.chirpstack.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "chirpstack.core" . }}
+      {{- with .Values.chirpstack.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chirpstack.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.chirpstack.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: /etc/chirpstack
           ports:
             - name: dashboard
-              containerPort: {{ .Values.chirpstack.http.port }}
+              containerPort: {{ .Values.chirpstack.http.containerPort }}
               protocol: TCP
             {{- if .Values.chirpstack.metrics.enabled }}
             - name: metrics

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -16,10 +16,10 @@ spec:
         {{- with .Values.chirpstack.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+        {{- if .Values.chirpstack.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "{{ .Values.chirpstack.entrypoints.metrics.port }}"
+        prometheus.io/port: "{{ .Values.chirpstack.metrics.port }}"
         {{- end }}
       labels:
         {{- include "chirpstack.selectorLabels" . | nindent 8 }}
@@ -30,11 +30,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Values.chirpstack.name }}
           securityContext:
-            {{- toYaml .Values.chirpstack.containerSecurityContext | nindent 12 }}
+            {{- toYaml .Values.chirpstack.securityContext | nindent 12 }}
           image: "{{ .Values.chirpstack.image.repository }}:{{ .Values.chirpstack.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
@@ -50,12 +50,12 @@ spec:
             - name: http
               containerPort: {{ .Values.chirpstack.entrypoints.http.port }}
               protocol: TCP
-            {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+            {{- if .Values.chirpstack.metrics.enabled }}
             - name: metrics
-              containerPort: {{ .Values.chirpstack.entrypoints.metrics.port }}
+              containerPort: {{ .Values.chirpstack.metrics.port }}
               protocol: TCP
             {{ end }}
-          {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+          {{- if .Values.chirpstack.metrics.enabled }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -55,16 +55,6 @@ spec:
               containerPort: {{ .Values.chirpstack.metrics.port }}
               protocol: TCP
             {{ end }}
-          {{- if .Values.chirpstack.metrics.enabled }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: metrics
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: metrics
-          {{- else }}
           livenessProbe:
             httpGet:
               path: /
@@ -73,7 +63,6 @@ spec:
             httpGet:
               path: /
               port: dashboard
-          {{ end }}
           resources:
             {{- toYaml .Values.chirpstack.resources | nindent 12 }}
       volumes:

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: config
               mountPath: /etc/chirpstack
           ports:
-            - name: http
+            - name: dashboard
               containerPort: {{ .Values.chirpstack.http.port }}
               protocol: TCP
             {{- if .Values.chirpstack.metrics.enabled }}
@@ -68,11 +68,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: http
+              port: dashboard
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: dashboard
           {{ end }}
           resources:
             {{- toYaml .Values.chirpstack.resources | nindent 12 }}

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: /etc/chirpstack
           ports:
             - name: http
-              containerPort: {{ .Values.chirpstack.entrypoints.http.port }}
+              containerPort: {{ .Values.chirpstack.http.port }}
               protocol: TCP
             {{- if .Values.chirpstack.metrics.enabled }}
             - name: metrics

--- a/charts/chirpstack/templates/chirpstack/ingress.yaml
+++ b/charts/chirpstack/templates/chirpstack/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.chirpstack.ingress.enabled -}}
 {{- $fullName := include "chirpstack.core" . -}}
-{{- $svcPort := .Values.chirpstack.entrypoints.http.port -}}
+{{- $svcPort := .Values.chirpstack.http.port -}}
 {{- if and .Values.chirpstack.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.chirpstack.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.chirpstack.ingress.annotations "kubernetes.io/ingress.class" .Values.chirpstack.ingress.className}}

--- a/charts/chirpstack/templates/chirpstack/ingress.yaml
+++ b/charts/chirpstack/templates/chirpstack/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.chirpstack.ingress.enabled -}}
+{{- $fullName := include "chirpstack.core" . -}}
+{{- $svcPort := .Values.chirpstack.entrypoints.http.port -}}
+{{- if and .Values.chirpstack.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.chirpstack.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.chirpstack.ingress.annotations "kubernetes.io/ingress.class" .Values.chirpstack.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+  {{- with .Values.chirpstack.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.chirpstack.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.chirpstack.ingress.className }}
+  {{- end }}
+  {{- if .Values.chirpstack.ingress.tls }}
+  tls:
+    {{- range .Values.chirpstack.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.chirpstack.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chirpstack.core" . }}
+  labels:
+    {{- include "chirpstack.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.chirpstack.entrypoints.http.port }}
+      targetPort: {{ .Values.chirpstack.entrypoints.http.targetPort }}
+      protocol: TCP
+      name: http
+
+    {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
+    - port: {{ .Values.chirpstack.entrypoints.metrics.port }}
+      targetPort: {{ .Values.chirpstack.entrypoints.metrics.targetPort }}
+      protocol: TCP
+      name: metrics
+    {{ end }}
+  selector:
+    {{- include "chirpstack.selectorLabels" . | nindent 4 }}

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -8,13 +8,13 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.chirpstack.http.port }}
-      targetPort: {{ .Values.chirpstack.http.targetPort }}
+      targetPort: dashboard
       protocol: TCP
-      name: http
+      name: dashboard
 
     {{- if .Values.chirpstack.metrics.enabled }}
     - port: {{ .Values.chirpstack.metrics.port }}
-      targetPort: {{ .Values.chirpstack.metrics.port }}
+      targetPort: metrics
       protocol: TCP
       name: metrics
     {{ end }}

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -4,8 +4,15 @@ metadata:
   name: {{ include "chirpstack.core" . }}
   labels:
     {{- include "chirpstack.labels" . | nindent 4 }}
+  {{- with .Values.chirpstack.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.chirpstack.service.type }}
+  {{- with .Values.chirpstack.service.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   ports:
     - port: {{ .Values.chirpstack.http.port }}
       targetPort: {{ .Values.chirpstack.http.containerPort }}

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.chirpstack.entrypoints.http.port }}
-      targetPort: {{ .Values.chirpstack.entrypoints.http.targetPort }}
+    - port: {{ .Values.chirpstack.http.port }}
+      targetPort: {{ .Values.chirpstack.http.targetPort }}
       protocol: TCP
       name: http
 

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -12,9 +12,9 @@ spec:
       protocol: TCP
       name: http
 
-    {{- if .Values.chirpstack.entrypoints.metrics.enabled }}
-    - port: {{ .Values.chirpstack.entrypoints.metrics.port }}
-      targetPort: {{ .Values.chirpstack.entrypoints.metrics.targetPort }}
+    {{- if .Values.chirpstack.metrics.enabled }}
+    - port: {{ .Values.chirpstack.metrics.port }}
+      targetPort: {{ .Values.chirpstack.metrics.port }}
       protocol: TCP
       name: metrics
     {{ end }}

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -11,13 +11,6 @@ spec:
       targetPort: dashboard
       protocol: TCP
       name: dashboard
-
-    {{- if .Values.chirpstack.metrics.enabled }}
-    - port: {{ .Values.chirpstack.metrics.port }}
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
-    {{ end }}
   selector:
     {{- include "chirpstack.selectorLabels" . | nindent 4 }}
     component: core

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.chirpstack.http.port }}
-      targetPort: dashboard
+      targetPort: {{ .Values.chirpstack.http.containerPort }}
       protocol: TCP
       name: dashboard
   selector:

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -20,3 +20,4 @@ spec:
     {{ end }}
   selector:
     {{- include "chirpstack.selectorLabels" . | nindent 4 }}
+    component: core

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -90,6 +90,11 @@ chirpstack:
       #   hosts:
       #     - chirpstack.example.com
 
+  service:
+    type: ClusterIP
+    annotations: {}
+    spec: {}
+
   podAnnotations: {}
 
   podSecurityContext: {}
@@ -158,6 +163,11 @@ chirpstackRestApi:
       # - secretName: my-certificate
       #   hosts:
       #     - chirpstack.example.com
+
+  service:
+    type: ClusterIP
+    annotations: {}
+    spec: {}
 
   podAnnotations: {}
 

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -10,8 +10,8 @@ chirpstack:
   name: chirpstack
   replicaCount: 1
 
-  command: ["chirpstack", "-c", "/etc/chirpstack"]
-  args: []
+  command: []
+  args: ["--config", "/etc/chirpstack"]
 
   logLevel: info
   apiSecret: "you-must-replace-me"
@@ -68,7 +68,10 @@ chirpstack:
     className: ""
     annotations: {}
     hosts:
-      # - chirpstack.example.com
+      # - host: chirpstack.example.com
+      #   paths:
+      #     - path: /
+      #       pathType: Prefix
     tls: []
       # - secretName: my-certificate
       #   hosts:

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -1,0 +1,108 @@
+# Default values for chirpstack.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+chirpstack:
+  name: chirpstack
+  replicaCount: 1
+
+  command: ["chirpstack", "-c", "/etc/chirpstack"]
+  args: []
+
+  logLevel: info
+  apiSecret: "you-must-replace-me"
+
+  extraEnvs: []
+    # - name: MY_VAR
+    #   value: myValue
+
+  image:
+    repository: chirpstack/chirpstack
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  postgres:
+    user: postgres
+    password: postgres
+    host: localhost
+    database: chirpstack
+    sslMode: disable
+
+  redis:
+    servers:
+      - redis://localhost/
+
+    tlsEnabled: false
+    cluster: false
+
+  regions:
+    eu868:
+      mqtt:
+        host: localhost
+        port: 1883
+
+        eventTopic: eu868/gateway/+/event/+
+        commandTopic: eu868/gateway/{{ gateway_id }}/command/{{ command }}
+
+  network:
+    netId: "000000"
+    enabledRegions:
+      - eu868
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  entrypoints:
+    http:
+      port: 8080
+      targetPort: 8080
+    metrics:
+      enabled: true
+      port: 8081
+      targetPort: 8081
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      # - chirpstack.example.com
+    tls: []
+      # - secretName: my-certificate
+      #   hosts:
+      #     - chirpstack.example.com
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -54,10 +54,9 @@ chirpstack:
     enabledRegions:
       - eu868
 
-  entrypoints:
-    http:
-      port: 8080
-      targetPort: 8080
+  http:
+    port: 8080
+    targetPort: 8080
 
   metrics:
     enabled: true

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -1,72 +1,110 @@
-# Default values for chirpstack.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# Default values for ChirpStack.
 
+# Global Docker registry secret names as an array
 imagePullSecrets: []
+
+# Overrides for the name and full name of the chart
 nameOverride: ""
 fullnameOverride: ""
 
+# Configuration values for the ChirpStack LNS
 chirpstack:
+  # Name and replica count of the ChirpStack core app
   name: chirpstack
   replicaCount: 1
 
+  # Overrides for the default container command and args
   command: []
   args: ["--config", "/etc/chirpstack"]
 
+  # Log level of ChirpStack (must be either "trace", "debug", "info", "warn" or "error")
   logLevel: info
+
+  # Secret used for generating login and API tokens
+  # Replace it with e.g. the output of "openssl rand -base64 32"
   apiSecret: "you-must-replace-me"
 
+  # Extra environment variables to set in the containers
   extraEnvs: []
     # - name: MY_VAR
     #   value: myValue
 
+  # Overrides for the image being pulled from the Docker registry
   image:
     repository: chirpstack/chirpstack
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  # Configuration for connecting to the PostgreSQL database
   postgres:
+    # PostgreSQL user credentials
     user: postgres
     password: postgres
+
+    # Hostname of the database server
     host: localhost
+
+    # Name of the database to use for ChirpStack
     database: chirpstack
+
+    # SSL mode options:
+    #  * disable - no SSL
+    #  * require - Always SSL (skip verification)
+    #  * verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
+    #  * verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
     sslMode: disable
 
+  # Configuration for connecting to the Redis
   redis:
+    # Hostnames of the Redis servers (set multiple hostnames when connecting to a cluster)
     servers:
       - redis://localhost/
 
+    # Whether to connect to Redis with TLS
     tlsEnabled: false
+
+    # Whether the hostnames are a Redis Cluster instance
     cluster: false
 
+  # Configuration for the LoRa regions
   regions:
+    # Global MQTT gateway backend configuration
     mqtt:
+      # Hostname and port of the MQTT broker where the LoRaWAN gateways are connected
       host: localhost
       port: 1883
 
+    # Configuration for the EU868 region
     eu868:
       mqtt:
-        # Overrides for the global MQTT host definition
+        # Overrides for the global MQTT hostname and port
         # host: localhost
         # port: 1883
 
+        # Event and command topics
         eventTopic: eu868/gateway/+/event/+
         commandTopic: eu868/gateway/{{ gateway_id }}/command/{{ command }}
 
+  # LNS network configuration
   network:
+    # 3 bytes network identifier encoded as hex
     netId: "000000"
+
+    # LoRa regions enabled on this instance
     enabledRegions:
       - eu868
 
+  # Configuration of the ChirpStack dashboard server
   http:
     port: 8080
     containerPort: 8080
 
+  # Configuration of the ChirpStack metrics server
   metrics:
     enabled: true
     port: 8081
 
+  # Extra config files that are mounted in the configuration directory
   extraConfigFiles: {}
     # kafka.toml: |
     #   [integration]
@@ -76,6 +114,7 @@ chirpstack:
     #       brokers=["localhost:9092"]
     #       topic="chirpstack"
 
+  # Configuration of the ingress to the dashboard
   ingress:
     enabled: false
     className: ""
@@ -90,6 +129,7 @@ chirpstack:
       #   hosts:
       #     - chirpstack.example.com
 
+  # Configuration of the main ChirpStack service
   service:
     type: ClusterIP
     annotations: {}
@@ -124,32 +164,42 @@ chirpstack:
   tolerations: []
   affinity: {}
 
+# Configuration values for the ChirpStack REST API bridge
 chirpstackRestApi:
+  # Whether the REST API service is deployed
   enabled: true
 
+  # Name and replica count of the ChirpStack REST API app
   name: chirpstack-rest-api
   replicaCount: 1
 
+  # Overrides for the default container command and args
   command: []
   args: []
 
+  # Extra environment variables to set in the containers
   extraEnvs: []
     # - name: MY_VAR
     #   value: myValue
 
+  # Overrides for the image being pulled from the Docker registry
   image:
     repository: chirpstack/chirpstack-rest-api
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  # Configuration of the ChirpStack REST API server
   http:
+    # Indicates that the gRPC interface is not secured using a TLS certificate
     insecure: true
+
+    # CORS AllowedOrigins header value
     cors: "0.0.0.0"
 
     port: 8090
     containerPort: 8090
 
+  # Configuration of the ingress to the dashboard
   ingress:
     enabled: false
     className: ""
@@ -164,6 +214,7 @@ chirpstackRestApi:
       #   hosts:
       #     - chirpstack.example.com
 
+  # Configuration of the main ChirpStack service
   service:
     type: ClusterIP
     annotations: {}

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -54,18 +54,14 @@ chirpstack:
     enabledRegions:
       - eu868
 
-  service:
-    type: ClusterIP
-    port: 8080
-
   entrypoints:
     http:
       port: 8080
       targetPort: 8080
-    metrics:
-      enabled: true
-      port: 8081
-      targetPort: 8081
+
+  metrics:
+    enabled: true
+    port: 8081
 
   ingress:
     enabled: false

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -61,7 +61,7 @@ chirpstack:
 
   http:
     port: 8080
-    targetPort: 8080
+    containerPort: 8080
 
   metrics:
     enabled: true
@@ -134,7 +134,7 @@ chirpstackRestApi:
     cors: "0.0.0.0"
 
     port: 8090
-    targetPort: 8090
+    containerPort: 8090
 
   ingress:
     enabled: false

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -102,3 +102,72 @@ chirpstack:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+chirpstackRestApi:
+  enabled: true
+
+  name: chirpstack-rest-api
+  replicaCount: 1
+
+  command: []
+  args: []
+
+  extraEnvs: []
+    # - name: MY_VAR
+    #   value: myValue
+
+  image:
+    repository: chirpstack/chirpstack-rest-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  http:
+    insecure: true
+    cors: "0.0.0.0"
+
+    port: 8090
+    targetPort: 8090
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      # - host: chirpstack-api.example.com
+      #   paths:
+      #     - path: /
+      #       pathType: Prefix
+    tls: []
+      # - secretName: my-certificate
+      #   hosts:
+      #     - chirpstack.example.com
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -41,10 +41,15 @@ chirpstack:
     cluster: false
 
   regions:
+    mqtt:
+      host: localhost
+      port: 1883
+
     eu868:
       mqtt:
-        host: localhost
-        port: 1883
+        # Overrides for the global MQTT host definition
+        # host: localhost
+        # port: 1883
 
         eventTopic: eu868/gateway/+/event/+
         commandTopic: eu868/gateway/{{ gateway_id }}/command/{{ command }}

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -67,6 +67,15 @@ chirpstack:
     enabled: true
     port: 8081
 
+  extraConfigFiles: {}
+    # kafka.toml: |
+    #   [integration]
+    #     enabled=["kafka"]
+    #
+    #     [integration.kafka]
+    #       brokers=["localhost:9092"]
+    #       topic="chirpstack"
+
   ingress:
     enabled: false
     className: ""


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?
This adds the helm chart for deploying ChirpStack and its REST API bridge.

ChirpStack dependencies (Postgres, Redis & an MQTT broker) must be deployed separately, and the hosts of those services must be set accordingly when installing this chart.
