### PR TITLE
Fix Kuzzle chart container ports

### DIFF
--- a/charts/kuzzle/Chart.yaml
+++ b/charts/kuzzle/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.3
+appVersion: 1.0.4

--- a/charts/kuzzle/templates/deployment.yaml
+++ b/charts/kuzzle/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      
+
       # Init containers
       {{ if .Values.extraInitContainers }}
       initContainers:
@@ -46,34 +46,34 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env: 
-            {{- toYaml .Values.extraEnvs | nindent 12 }} 
-          command: 
+          env:
+            {{- toYaml .Values.extraEnvs | nindent 12 }}
+          command:
             {{- toYaml .Values.command | nindent 12 }}
-          args: 
+          args:
             {{- toYaml .Values.args | nindent 12 }}
           ports:
             - name: kuzzle-api
-              containerPort: {{ .Values.entrypoints.http.port }}
+              containerPort: {{ .Values.entrypoints.http.targetPort }}
               protocol: TCP
             - name: cluster-command
-              containerPort: {{ .Values.entrypoints.cluster_command.port }}
+              containerPort: {{ .Values.entrypoints.cluster_command.targetPort }}
               protocol: TCP
             - name: cluster-sync
-              containerPort: {{ .Values.entrypoints.cluster_sync.port }}
+              containerPort: {{ .Values.entrypoints.cluster_sync.targetPort }}
               protocol: TCP
           {{- range .Values.extraEntrypoints }}
             - name: {{ .name }}
-              containerPort: {{ .port }}
+              containerPort: {{ .targetPort }}
               protocol: {{ .protocol }}
           {{- end }}
         {{- with .Values.probes.liveness }}
           livenessProbe:
-            {{- toYaml . | nindent 12 }} 
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with .Values.probes.readiness }}
           readinessProbe:
-            {{- toYaml . | nindent 12 }} 
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?
The container ports in the deployment resource of the Kuzzle Helm chart were incorrectly set to the value of the `port` key instead of the `targetPort` key.

This PR fixes that.