### PR TITLE
ChirpStack: disable metrics and rest api, use well-known component selector

### DIFF
--- a/charts/chirpstack/Chart.yaml
+++ b/charts/chirpstack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- include "chirpstack.selectorLabels" . | nindent 6 }}
-      component: restApi
+      app.kubernetes.io/component: restApi
   template:
     metadata:
       annotations:
@@ -19,7 +19,7 @@ spec:
         {{- end }}
       labels:
         {{- include "chirpstack.selectorLabels" . | nindent 8 }}
-        component: restApi
+        app.kubernetes.io/component: restApi
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
+++ b/charts/chirpstack/templates/chirpstack-rest-api/service.yaml
@@ -21,5 +21,5 @@ spec:
       name: api
   selector:
     {{- include "chirpstack.selectorLabels" . | nindent 4 }}
-    component: restApi
+    app.kubernetes.io/component: restApi
 {{- end }}

--- a/charts/chirpstack/templates/chirpstack/deployment.yaml
+++ b/charts/chirpstack/templates/chirpstack/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "chirpstack.selectorLabels" . | nindent 6 }}
-      component: core
+      app.kubernetes.io/component: core
   template:
     metadata:
       annotations:
@@ -23,7 +23,7 @@ spec:
         {{- end }}
       labels:
         {{- include "chirpstack.selectorLabels" . | nindent 8 }}
-        component: core
+        app.kubernetes.io/component: core
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/chirpstack/templates/chirpstack/service.yaml
+++ b/charts/chirpstack/templates/chirpstack/service.yaml
@@ -20,4 +20,4 @@ spec:
       name: dashboard
   selector:
     {{- include "chirpstack.selectorLabels" . | nindent 4 }}
-    component: core
+    app.kubernetes.io/component: core

--- a/charts/chirpstack/values.yaml
+++ b/charts/chirpstack/values.yaml
@@ -101,7 +101,7 @@ chirpstack:
 
   # Configuration of the ChirpStack metrics server
   metrics:
-    enabled: true
+    enabled: false
     port: 8081
 
   # Extra config files that are mounted in the configuration directory
@@ -167,7 +167,7 @@ chirpstack:
 # Configuration values for the ChirpStack REST API bridge
 chirpstackRestApi:
   # Whether the REST API service is deployed
-  enabled: true
+  enabled: false
 
   # Name and replica count of the ChirpStack REST API app
   name: chirpstack-rest-api


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

This disables by default the ChirpStack metrics server and the REST API component to have a lighter default install.

Labels named `component` were also renamed to `app.kubernetes.io/component` as it is a well-known label.