### PR TITLE
fix: add default value for ingressTCP.enabled in paas-webapp

### DIFF
--- a/charts/paas-webapp/Chart.yaml
+++ b/charts/paas-webapp/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paas-webapp/README.md
+++ b/charts/paas-webapp/README.md
@@ -1,6 +1,6 @@
 # paas-webapp
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.26.0](https://img.shields.io/badge/AppVersion-1.26.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,6 +16,7 @@ A Helm chart for Kubernetes
 | --------------------------------- | ------ | ----------------- | ----------- |
 | certificate.enabled               | bool   | `false`           |             |
 | ingress.enabled                   | bool   | `false`           |             |
+| ingressTCP.enabled                | bool   | `false`           |             |
 | secret.enabled                    | bool   | `false`           |             |
 | webapp.image.name                 | string | `"nginx"`         |             |
 | webapp.image.pullPolicy           | string | `"Always"`        |             |

--- a/charts/paas-webapp/values.yaml
+++ b/charts/paas-webapp/values.yaml
@@ -61,3 +61,6 @@ ingress:
   # tls:
   #   enabled: true
   #   secretName: webapp
+
+ingressTCP:
+  enabled: false


### PR DESCRIPTION
## What does this PR do ?

This adds a default value for `ingressTCP.enabled` in the `paas-webapp` chart.